### PR TITLE
docs: add git-native-issue vs Beads comparison

### DIFF
--- a/docs/comparisons/README.md
+++ b/docs/comparisons/README.md
@@ -1,0 +1,10 @@
+# Comparisons
+
+Detailed technical comparisons of git-native-issue against other distributed
+issue tracking tools.
+
+| Tool | Approach | Document |
+|------|----------|----------|
+| [Beads (bd)](https://github.com/gastownhall/beads) | Dolt SQL database | [beads.md](beads.md) |
+
+*More comparisons coming: git-bug, Fossil, Bugs Everywhere, git-appraise.*

--- a/docs/comparisons/beads.md
+++ b/docs/comparisons/beads.md
@@ -1,0 +1,374 @@
+# git-native-issue vs Beads (bd)
+
+> Last verified against Beads v1.0.2 (2026-04-20)
+
+[Beads](https://github.com/gastownhall/beads) is a Go-based distributed
+graph issue tracker powered by [Dolt](https://github.com/dolthub/dolt), a
+version-controlled SQL database. It was designed primarily for AI agent
+workflows: dependency graphs, ready queues, and JSON output for machine
+consumption.
+
+This document compares its approach to git-native-issue's Git-native model.
+
+## At a Glance
+
+| Dimension | git-native-issue | Beads (bd) |
+|-----------|-----------------|------------|
+| **Storage** | Git commits + refs + trailers | Dolt (version-controlled SQL) |
+| **Language** | POSIX Shell | Go |
+| **Codebase** | ~7K lines, 22 scripts | ~314K lines, 1,061 files |
+| **Dependencies** | Git (+ optional `gh`, `jq` for bridges) | 212 Go modules, Dolt engine |
+| **Install size** | 0 (shell scripts on PATH) | ~41-44MB compressed binary |
+| **Merge strategy** | Git's own merge primitives | Dolt cell-level merge |
+| **Formal spec** | [ISSUE-FORMAT.md](../../ISSUE-FORMAT.md) (33KB) | None (implementation is the spec) |
+| **License** | GPL-2.0 | MIT |
+| **Version** | v1.4.0 | v1.0.2 |
+| **Repo** | [remenoscodes/git-native-issue](https://github.com/remenoscodes/git-native-issue) | [gastownhall/beads](https://github.com/gastownhall/beads) |
+
+Both projects solve distributed issue tracking without a central server.
+The difference is architectural: git-native-issue treats Git as the
+database -- issues are commits, identity is refs, metadata is trailers,
+merge is Git merge. Beads brings a separate database (Dolt) alongside Git.
+git-native-issue does this with zero dependencies beyond Git itself, and
+produces a formal specification that any tool can implement.
+
+---
+
+## What They Have in Common
+
+Before diving into differences, it is worth noting the shared ground.
+Both projects reject centralized trackers (GitHub Issues, Jira, Linear) as
+single points of failure. Both use hash-based IDs for collision-free
+distributed work -- git-native-issue uses UUID v4, Beads uses content-hash
+in base36 (e.g. `bd-a3f8e9`). Both sync via push/pull rather than webhooks
+or polling. Both bridge to GitHub, GitLab, Gitea, and Azure DevOps.
+
+The shared DNA ends at the storage layer. Everything that follows stems from
+a single architectural fork.
+
+---
+
+## The Fundamental Fork
+
+Two competing theses:
+
+**Beads' thesis**: "Issues need a real database. Git is the wrong
+abstraction for queries and graphs." Beads ships Dolt -- a version-controlled
+SQL database with cell-level merge, native branching, and built-in sync --
+as its storage engine. Issues live in SQL tables with indexes, foreign keys,
+and joins.
+
+**git-native-issue's thesis**: "Git already IS a distributed, append-only,
+content-addressable database. Issues are just commits."
+
+git-native-issue uses only Git primitives that have existed for 20 years:
+commits as events, refs as identity, trailers as structured metadata, and
+Git's own merge machinery for conflict resolution. No new storage engine.
+No new protocol. No new binary.
+
+The rest of this document presents evidence for the Git-native thesis --
+while being honest about where the tradeoffs favor Beads.
+
+---
+
+## Storage: Commits + Refs + Trailers vs Dolt SQL
+
+### git-native-issue
+
+```
+refs/issues/<uuid>  -->  commit chain (append-only)
+    |-- root commit: title (subject) + metadata (trailers)
+    |-- comment commits: body text
+    |-- state-change commits: State: trailer
+    All point to empty tree (4b825dc...)
+```
+
+- **Human-readable**: `git log refs/issues/*` shows your issues
+- **Tamper-evident**: every commit is SHA-addressed; changing a byte changes
+  the hash
+- **Zero overhead**: no files in the working tree, no database files, no
+  `.beads/` directory
+- **Works everywhere**: bare repos, CI environments, embedded systems --
+  anywhere Git runs
+
+Every piece of issue data is a standard Git object. `git clone` copies your
+issues. `git push` shares them. `git fsck` validates them.
+
+### Beads
+
+```
+.beads/embeddeddolt/  -->  Dolt database
+    |-- issues table (id, title, status, priority, type, ...)
+    |-- dependencies table (graph edges)
+    |-- comments, events, labels, wisps, ...
+    |-- refs/dolt/data (Dolt's own ref namespace)
+```
+
+- **Full SQL power**: indexes, joins, foreign keys, ad-hoc queries
+- **Cell-level versioning**: every field change is tracked independently
+- **Large footprint**: Go binary with embedded Dolt engine (~41-44MB
+  compressed)
+- **Requires Dolt**: either embedded (in-process, single-writer) or server
+  mode (external `dolt sql-server`)
+
+Beads' storage is a parallel system alongside Git. It has Git-like
+properties (branching, merge, history), but it is not Git. Your issues
+live in a separate database. They do not travel with `git clone`.
+
+---
+
+## Merge: Git's Own Primitives vs an External Engine
+
+### How git-native-issue merges
+
+git-native-issue does not invent merge algorithms. It composes Git's
+existing primitives:
+
+- **Comments**: union of commit chains. When two branches diverge, merging
+  produces a commit with two parents -- both chains are preserved. This is
+  how Git merge works by default.
+- **Labels**: three-way set merge via `git merge-base` + `comm` + `sort`.
+  Additions from both sides are kept. Removals from both sides are honored.
+  On tie, additions beat removals (bias toward keeping data). These are
+  standard UNIX tools from the 1970s.
+- **Scalar fields** (assignee, priority, milestone): last-writer-wins via
+  `%(authordate)` -- Git's own author timestamp. Tiebreaker:
+  lexicographically greater SHA.
+- **Merge commits**: `git commit-tree` with two parents and resolved
+  metadata as trailers. Standard Git plumbing.
+
+The [ISSUE-FORMAT.md](../../ISSUE-FORMAT.md) spec contribution is policy
+decisions over these primitives -- which strategy applies to which field
+type -- not new algorithms. The strategies themselves are textbook
+distributed systems patterns implemented with Git commands.
+
+### How Beads merges
+
+Beads delegates merge entirely to Dolt's cell-level merge engine. Dolt
+performs a three-way merge at the SQL cell level. This is effective, but it
+is a black box: users must trust Dolt's merge semantics, which are not
+formally specified and may change between versions.
+
+git-native-issue's merge behavior is specified in a
+[formal document](../../ISSUE-FORMAT.md) that any implementation can follow.
+Beads' merge behavior is whatever Dolt does.
+
+---
+
+## The Dependency Graph Question
+
+Beads' strongest selling point is its dependency graph: `bd dep add/remove/tree`,
+`bd ready` (list unblocked tasks), and cycle detection. This is genuinely
+useful for AI agent workflows where agents need to ask "what can I work on
+next?"
+
+**Our argument: this is a data modeling problem, not a storage engine
+problem.**
+
+Git trailers model the same graph:
+
+```
+Blocks: a7f3b2c
+Blocked-By: c4e5f6d
+Parent: b8c9d0e
+Related: f1a2b3c
+```
+
+These are append-only (a new commit adds a trailer), merge-safe (union
+semantics -- same as comments), and queryable via Git plumbing.
+
+### The GitHub Issues analogy
+
+GitHub Issues has zero built-in hierarchy or dependency primitives. Yet
+millions of teams model epics, stories, tasks, and blockers using nothing
+but labels, mentions, and markdown checklists. git-native-issue's trailers
+are more structured than GitHub's freeform markdown -- they are typed,
+machine-parseable, and formally specified.
+
+### Query cost
+
+To be honest about the tradeoff: querying trailers requires iterating issue
+refs -- `git for-each-ref refs/issues/` to collect tips, then inspecting
+each tip commit's trailers. This is O(n) over all issues, not an indexed
+lookup like Dolt's SQL.
+
+For most repositories (hundreds of issues), this is fast -- the same pattern
+`git issue ls` already uses for filtering by label or priority. For
+thousands of issues, it is slower than SQL but still tractable. The tradeoff
+is: no new dependency for queries that are fast enough at realistic scale.
+
+### Cycle detection
+
+Detecting cycles in a trailer-based dependency graph requires a full DFS
+traversal across all `Blocks:`/`Blocked-By:` relationships. This is
+non-trivial but well-understood -- a standard graph algorithm. We do not
+pretend this is a one-liner.
+
+### A ready queue
+
+A ready queue is: "open issues where no unresolved `Blocked-By` target
+exists." This requires collecting all open issues' `Blocked-By` trailers,
+checking which targets are still open, and filtering. Not trivial, but the
+same algorithmic complexity as any graph-based ready queue -- including
+Beads'.
+
+### The bottom line
+
+Dependency tracking is a **feature gap** in git-native-issue today, not an
+**architectural limitation**. Closing it requires new trailers in the spec
+plus approximately five new commands (`dep add`, `dep remove`, `dep list`,
+`dep tree`, `ready`) with cycle detection and validation. Realistic
+estimate: 400-600 lines of shell. This is meaningful work, but proportional
+-- git-native-issue's existing commands average 100-150 lines each.
+
+Beads built a 314K-line Go application with 212 dependencies and a SQL
+database to solve a problem that structured metadata and smart queries can
+handle.
+
+---
+
+## Agent Integration
+
+Beads was designed agent-first: JSON output everywhere, atomic `--claim`
+(sets assignee + in_progress in one operation), `bd ready` (unblocked
+tasks), a built-in Anthropic SDK, and an MCP server on PyPI.
+
+git-native-issue approaches agent integration differently -- via plugins
+rather than baking agent concerns into the core tool. The
+[claude-git-native-issue](https://github.com/remenoscodes/claude-git-native-issue)
+plugin enables Claude Code to create, list, update, and close issues
+autonomously.
+
+To be clear: Beads is human-usable. It has a full CLI and TUI. The
+argument is not that Beads sacrificed human usability, but that
+agent-specific concerns -- molecules, gates, formulas, built-in LLM SDKs
+-- do not need to live in the issue tracker's core.
+
+Trailers are structured data. Agents consume them naturally. A `--json`
+output flag is a small addition to git-native-issue that closes the
+machine-readability gap without pulling in the Anthropic SDK as a
+dependency of the issue tracker.
+
+Agent orchestration belongs in orchestration tools. Issue tracking belongs
+in the issue tracker.
+
+---
+
+## What Beads Has That We Don't (And Whether It Matters)
+
+### Worth considering
+
+Features that close real gaps with small additions:
+
+- **`--json` output**: machine-readable output for agent consumption.
+  A natural addition to `git issue ls` and `git issue show`.
+- **Dependency trailers**: `Blocks:`, `Blocked-By:`, `Parent:`, `Related:`.
+  New trailers in the ISSUE-FORMAT.md spec, queryable with existing Git
+  plumbing.
+- **`git issue ready`**: list unblocked tasks. A new command built on
+  dependency trailers.
+- **`git issue dep tree`**: visualize the dependency graph. A new command
+  that reads `Blocks:`/`Blocked-By:` trailers and renders a tree.
+
+### Interesting but out of scope
+
+Features that solve real problems but belong in separate tools:
+
+- **Molecules, formulas, gates**: workflow orchestration primitives (compound
+  tasks, YAML recipes, async coordination). These are useful but they are
+  orchestration, not issue tracking.
+- **Hierarchical IDs** (`bd-a3f8.1.1`): convenient shorthand for sub-tasks,
+  but solvable with `Parent:` trailers without changing the ID scheme.
+- **Multi-repo federation**: interesting for enterprise deployments,
+  premature for v1.x of a tool focused on getting the primitives right.
+- **Contributor/maintainer roles**: auto-detection of repo access level.
+  Solves a Beads-specific problem (keeping planning databases out of PRs).
+
+### Unnecessary complexity
+
+Features that add weight without clear benefit for issue tracking:
+
+- **Wisps** (ephemeral TTL messages): adds complexity to an issue tracker
+  with unclear benefit. While append-only systems can support TTL (e.g.
+  Kafka retention), it is unclear why an issue tracker needs ephemeral
+  messages.
+- **Compaction/memory decay**: rewriting closed issue history to save AI
+  context windows. This trades auditability for a concern that belongs in
+  the agent, not the data store.
+- **OpenTelemetry**: structured observability for a CLI issue tracker. The
+  overhead of tracing infrastructure outweighs the diagnostic value for a
+  tool that runs in milliseconds.
+- **212 Go module dependencies**: a large dependency tree for functionality
+  that POSIX shell scripts handle with zero external dependencies.
+
+---
+
+## Feature Matrix
+
+| Category | Feature | git-native-issue | Beads (bd) |
+|----------|---------|-----------------|------------|
+| **Core** | Create issues | ✓ | ✓ |
+| | List/filter issues | ✓ | ✓ |
+| | Show issue details | ✓ | ✓ |
+| | Edit issue metadata | ✓ | ✓ |
+| | Change state (open/close) | ✓ | ✓ |
+| | Search issues | ✓ | ✓ |
+| | Add comments | ✓ | ✓ |
+| **Dependencies** | Add/remove dependencies | planned | ✓ |
+| | Dependency tree visualization | planned | ✓ |
+| | Ready queue (unblocked tasks) | planned | ✓ |
+| | Cycle detection | planned | ✓ |
+| | Epics / sub-tasks | planned (via `Parent:` trailer) | ✓ (hierarchical IDs) |
+| **Collaboration** | Assign issues | ✓ | ✓ |
+| | Atomic claim (assign + start) | -- | ✓ |
+| | Comment threading | -- | ✓ |
+| **Sync** | GitHub | ✓ (import/export/sync) | ✓ |
+| | GitLab | ✓ (import/export/sync) | ✓ |
+| | Gitea / Forgejo | ✓ (import/export) | ✓ |
+| | Azure DevOps | ✓ (import/export) | ✓ |
+| | Jira | -- | ✓ |
+| | Linear | -- | ✓ |
+| | DoltHub | N/A | ✓ |
+| **Agent support** | JSON output | planned | ✓ |
+| | MCP server | -- | ✓ |
+| | Claude plugin | ✓ (via plugin) | ✓ (built-in SDK) |
+| | Ready queue | planned | ✓ |
+| **Maintenance** | Data integrity validation | ✓ (`git issue fsck`) | ✓ (`bd doctor`) |
+| | Garbage collection | N/A (Git GC) | ✓ (`bd gc`) |
+| | Compaction | N/A -- by design | ✓ (`bd compact`) |
+| **Data properties** | Tamper-evident (SHA-addressed) | ✓ | -- |
+| | Human-readable (`git log`) | ✓ | -- |
+| | Formal interop spec | ✓ (ISSUE-FORMAT.md) | -- |
+| | Works in bare repos | ✓ | -- |
+| | Zero dependencies beyond Git | ✓ | -- |
+| | Travels with `git clone` | ✓ | -- |
+| | SQL ad-hoc queries | -- | ✓ |
+| | Cell-level field versioning | -- | ✓ |
+
+Legend: `✓` = available, `planned` = on roadmap, `--` = not available,
+`N/A` = not applicable by design.
+
+---
+
+## When to Use Which
+
+**Use git-native-issue when:**
+
+- You already use Git and want zero new dependencies
+- Issues should travel with your code (`git clone` copies your issues)
+- You value a formal spec that other tools can implement
+- Human readability matters (`git log` shows your issues)
+- You work in constrained environments (CI, bare repos, air-gapped systems)
+- You want issue data that is tamper-evident by construction
+
+**Consider Beads when:**
+
+- Your primary users are AI agents, not humans
+- You need complex SQL queries over issue data
+- Your team already uses Dolt
+- You need Jira or Linear sync specifically
+- You need dependency graph queries at scale (thousands of issues)
+
+Both are honest tools built by people who care about distributed issue
+tracking. They differ on a single architectural question: whether Git is
+enough. We believe it is.

--- a/docs/superpowers/plans/2026-04-20-beads-comparison.md
+++ b/docs/superpowers/plans/2026-04-20-beads-comparison.md
@@ -1,0 +1,379 @@
+# Beads Comparison Document — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Write `docs/comparisons/beads.md` — a public-facing technical comparison of git-native-issue vs Beads (bd), the first entry in a comparison document series.
+
+**Architecture:** Single markdown document with 10 sections, written incrementally. Each task produces one or two sections, verified for factual accuracy against both projects' source code, then committed. A final task creates the comparisons directory README.
+
+**Tech Stack:** Markdown. Reference sources: git-native-issue repo (local), Beads repo (cloned to /tmp/beads), Beads GitHub releases API for binary size data.
+
+**Spec:** `docs/superpowers/specs/2026-04-20-beads-comparison-design.md`
+
+---
+
+### File Map
+
+- **Create:** `docs/comparisons/beads.md` — the comparison document
+- **Create:** `docs/comparisons/README.md` — index for the comparison series
+- **Reference:** `README.md` (Prior Art section, lines 631-648)
+- **Reference:** `ISSUE-FORMAT.md` (merge rules, trailer spec)
+- **Reference:** `/tmp/beads/README.md` (Beads features, commands)
+- **Reference:** `/tmp/beads/LICENSE` (MIT)
+- **Reference:** Beads v1.0.2 release assets (binary sizes)
+
+---
+
+### Task 1: Create comparisons directory + header + At a Glance table
+
+**Files:**
+- Create: `docs/comparisons/beads.md`
+
+- [ ] **Step 1: Create the document with header and At a Glance table**
+
+Write the document header including:
+- Title: `git-native-issue vs Beads (bd)`
+- Metadata line: `Last verified against Beads v1.0.2 (2026-04-20)`
+- Intro quote describing what Beads is
+- At a Glance table with these rows:
+
+| Dimension | git-native-issue | Beads (bd) |
+|-----------|-----------------|------------|
+| **Storage** | Git commits + refs + trailers | Dolt (version-controlled SQL) |
+| **Language** | POSIX Shell | Go |
+| **Codebase** | ~5K lines, 25 scripts | ~314K lines, 1,061 files |
+| **Dependencies** | Git (+ optional `gh`, `jq` for bridges) | 212 Go modules, Dolt engine |
+| **Install size** | 0 (shell scripts on PATH) | ~41-44MB compressed (~80-100MB binary) |
+| **Merge strategy** | Git's own merge primitives | Dolt cell-level merge |
+| **Formal spec** | ISSUE-FORMAT.md (33KB) | None (implementation is the spec) |
+| **License** | GPL-2.0 | MIT |
+| **Version** | v1.4.0 | v1.0.2 |
+| **Repo** | `remenoscodes/git-native-issue` | `gastownhall/beads` |
+
+Then the one-paragraph verdict.
+
+- [ ] **Step 2: Verify table data accuracy**
+
+Cross-check each cell:
+- git-native-issue line count: `wc -l bin/git-issue-*` + `wc -l bridge/*`
+- Beads line count: already verified (314K Go lines, 1061 files)
+- Beads install size: already verified from `gh release view v1.0.2` (41MB darwin_arm64, 44MB linux_amd64)
+- Beads license: already verified (MIT)
+- git-native-issue version: check `bin/git-issue-version` or `CHANGELOG.md`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/comparisons/beads.md
+git commit -m "docs(comparisons): add beads comparison header and At a Glance table"
+```
+
+---
+
+### Task 2: Sections 2-3 — Common Ground + The Fundamental Fork
+
+**Files:**
+- Modify: `docs/comparisons/beads.md`
+
+- [ ] **Step 1: Write Section 2 — What They Have in Common**
+
+~150 words. Four bullet points from the spec:
+- Both reject centralized trackers as single points of failure
+- Both use hash-based IDs (UUID v4 vs content-hash base36)
+- Both sync via push/pull
+- Both bridge to GitHub, GitLab, Gitea, Azure DevOps
+
+- [ ] **Step 2: Write Section 3 — The Fundamental Fork**
+
+~300 words. The philosophical centerpiece:
+- Name both theses explicitly
+- Beads: "Issues need a real database"
+- git-native-issue: "Git already IS the database"
+- Frame the rest of the document as evidence
+
+- [ ] **Step 3: Verify claims**
+
+Confirm Beads' README describes Dolt as its storage engine. Confirm git-native-issue's README describes the "Git as database" philosophy.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/comparisons/beads.md
+git commit -m "docs(comparisons): add common ground and fundamental fork sections"
+```
+
+---
+
+### Task 3: Section 4 — Storage Comparison
+
+**Files:**
+- Modify: `docs/comparisons/beads.md`
+
+- [ ] **Step 1: Write Section 4 — Storage**
+
+~400 words. Two subsections with ASCII diagrams:
+
+**git-native-issue model** — commit chain under `refs/issues/<uuid>`, empty tree, trailers as metadata. Bullet points: human-readable, tamper-evident, zero overhead, works in bare repos.
+
+**Beads model** — Dolt database in `.beads/embeddeddolt/`, SQL tables (issues, dependencies, comments, events, labels, wisps). Bullet points: full SQL power, cell-level versioning, large footprint, requires Dolt engine.
+
+Closing argument: git-native-issue's storage IS Git; Beads' storage is a parallel system.
+
+- [ ] **Step 2: Verify storage details**
+
+Check Beads README and source for exact table names. Check git-native-issue's ISSUE-FORMAT.md for the exact empty tree SHA and ref format.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/comparisons/beads.md
+git commit -m "docs(comparisons): add storage architecture comparison"
+```
+
+---
+
+### Task 4: Section 5 — Merge Comparison
+
+**Files:**
+- Modify: `docs/comparisons/beads.md`
+
+- [ ] **Step 1: Write Section 5 — Merge**
+
+~300 words. Show that git-native-issue composes Git's existing merge primitives:
+- Comments: union of commit chains
+- Labels: three-way set merge via `git merge-base` + `comm` + `sort`
+- Scalars: LWW via `%(authordate)`
+- Merge commits: `git commit-tree` with two parents
+
+The ISSUE-FORMAT.md contribution is policy (which strategy per field), not new algorithms.
+
+Contrast: Beads delegates to Dolt's cell-level merge engine — a black box.
+
+- [ ] **Step 2: Verify merge details**
+
+Read ISSUE-FORMAT.md merge section to confirm the exact strategies. Check that the Git commands referenced are accurate.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/comparisons/beads.md
+git commit -m "docs(comparisons): add merge strategy comparison"
+```
+
+---
+
+### Task 5: Section 6 — The Dependency Graph Question
+
+**Files:**
+- Modify: `docs/comparisons/beads.md`
+
+- [ ] **Step 1: Write Section 6 — Dependencies**
+
+~600 words. The key rebuttal. Structure:
+
+1. Name Beads' strongest feature (dependency graph, ready queue, cycle detection)
+2. Argue: data modeling problem, not storage engine problem
+3. Show trailer-based graph model (`Blocks:`, `Blocked-By:`, `Parent:`, `Related:`)
+4. **Querying subsection**: honest about O(n) cost, argue "fast enough at realistic scale"
+5. **Cycle detection subsection**: non-trivial DFS, acknowledge implementation cost
+6. GitHub Issues analogy: models epics/stories/tasks with zero built-in hierarchy
+7. Ready queue: "open issues with no unresolved Blocked-By targets"
+8. Closing: feature gap today, not architectural limitation. ~400-600 lines of shell to close it.
+
+- [ ] **Step 2: Verify Beads' dependency features**
+
+Check Beads README for exact `bd dep` commands, `bd ready` behavior, and cycle detection. Ensure we're not misrepresenting their feature set.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/comparisons/beads.md
+git commit -m "docs(comparisons): add dependency graph question section"
+```
+
+---
+
+### Task 6: Section 7 — Agent Integration
+
+**Files:**
+- Modify: `docs/comparisons/beads.md`
+
+- [ ] **Step 1: Write Section 7 — Agent Integration**
+
+~250 words. Cover:
+- Beads' agent-first design: JSON output, `--claim`, `bd ready`, Anthropic SDK, MCP server
+- git-native-issue's plugin approach (claude-git-native-issue)
+- Note: Beads IS human-usable (full CLI + TUI)
+- Argument: agent concerns don't need to live in the issue tracker core
+- `--json` flag is a small addition; trailers ARE structured data
+
+- [ ] **Step 2: Verify Beads' agent features**
+
+Check Beads README for MCP server, Anthropic SDK integration, `--claim` flag, `--json` flag.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/comparisons/beads.md
+git commit -m "docs(comparisons): add agent integration comparison"
+```
+
+---
+
+### Task 7: Section 8 — Honest Assessment (What They Have That We Don't)
+
+**Files:**
+- Modify: `docs/comparisons/beads.md`
+
+- [ ] **Step 1: Write Section 8 — Tiered Assessment**
+
+~400 words. Three tiers:
+
+**Tier 1 — Worth considering:**
+- `--json` output flag
+- Dependency trailers (`Blocks:`, `Blocked-By:`, `Parent:`)
+- `git issue ready` command
+- `git issue dep tree` command
+
+**Tier 2 — Interesting but out of scope:**
+- Molecules, formulas, gates (workflow orchestration)
+- Hierarchical IDs (solvable with `Parent:` trailers)
+- Multi-repo federation (premature for v1.x)
+- Contributor/maintainer roles (Beads-specific problem)
+
+**Tier 3 — Unnecessary complexity:**
+- Wisps (unclear benefit for issue tracking)
+- Compaction (trades auditability for AI context window optimization)
+- OpenTelemetry (observability for a CLI issue tracker?)
+- 212 Go module dependencies
+
+- [ ] **Step 2: Verify each feature exists in Beads**
+
+Spot-check molecules, gates, wisps, formulas, OpenTelemetry in Beads source/README.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/comparisons/beads.md
+git commit -m "docs(comparisons): add tiered honest assessment"
+```
+
+---
+
+### Task 8: Section 9 — Feature Matrix
+
+**Files:**
+- Modify: `docs/comparisons/beads.md`
+
+- [ ] **Step 1: Write the comprehensive feature matrix**
+
+Large table grouped by category:
+
+**Core Operations:**
+| Feature | git-native-issue | Beads |
+Create, list, show, edit, state change, search, comment — both have these.
+
+**Dependencies & Hierarchy:**
+Dependency add/remove/tree, ready queue, cycle detection, epics, sub-tasks — Beads has, git-native-issue planned/N/A.
+
+**Collaboration:**
+Assign, claim, comment threading — mix of both.
+
+**Sync & Bridges:**
+GitHub, GitLab, Gitea, Azure DevOps (both), Jira, Linear (Beads only), DoltHub (Beads only).
+
+**Agent Support:**
+JSON output, MCP server, ready queue, atomic claim, built-in LLM SDK — Beads has most, git-native-issue has plugin approach.
+
+**Maintenance:**
+fsck (git-native-issue), compact/gc/doctor (Beads).
+
+**Data Properties:**
+Tamper-evident, human-readable (`git log`), formal spec, bare repo support, zero dependencies — git-native-issue advantages.
+
+Use: `✓`, `planned`, `—` (not applicable), `via plugin`.
+
+- [ ] **Step 2: Cross-verify every cell**
+
+For each "✓" in the Beads column, confirm the feature exists via README or source. For each "✓" in the git-native-issue column, confirm via existing commands.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/comparisons/beads.md
+git commit -m "docs(comparisons): add comprehensive feature matrix"
+```
+
+---
+
+### Task 9: Section 10 — When to Use Which
+
+**Files:**
+- Modify: `docs/comparisons/beads.md`
+
+- [ ] **Step 1: Write Section 10 — Closing Guidance**
+
+~200 words. Two subsections:
+
+**Use git-native-issue when:**
+- You already use Git and want zero new dependencies
+- Issues should travel with your code (clone includes issues)
+- You value a formal spec that other tools can implement
+- Human readability matters (`git log` shows issues)
+- You work in constrained environments (CI, bare repos, embedded systems)
+
+**Consider Beads when:**
+- Your primary users are AI agents, not humans
+- You need complex SQL queries over issue data
+- Your team already uses Dolt
+- You need Jira/Linear sync specifically
+- You need dependency graph queries at scale (thousands of issues)
+
+Honest, not dismissive.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/comparisons/beads.md
+git commit -m "docs(comparisons): add closing guidance section"
+```
+
+---
+
+### Task 10: Comparisons README + Final Review
+
+**Files:**
+- Create: `docs/comparisons/README.md`
+- Modify: `docs/comparisons/beads.md` (if final review finds issues)
+
+- [ ] **Step 1: Create `docs/comparisons/README.md`**
+
+```markdown
+# Comparisons
+
+Detailed technical comparisons of git-native-issue against other
+distributed issue tracking tools.
+
+| Tool | Approach | Document |
+|------|----------|----------|
+| [Beads (bd)](https://github.com/gastownhall/beads) | Dolt SQL database | [beads.md](beads.md) |
+
+*More comparisons coming: git-bug, Fossil, Bugs Everywhere, git-appraise.*
+```
+
+- [ ] **Step 2: Read the full document end-to-end**
+
+Read `docs/comparisons/beads.md` from top to bottom. Check:
+- Flow: does each section build on the previous?
+- Tone: advocacy with honesty, not dismissive?
+- Accuracy: all claims verified?
+- Completeness: all 10 sections present?
+
+- [ ] **Step 3: Fix any issues found in review**
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/comparisons/README.md docs/comparisons/beads.md
+git commit -m "docs(comparisons): add series README and finalize beads comparison"
+```

--- a/docs/superpowers/specs/2026-04-20-beads-comparison-design.md
+++ b/docs/superpowers/specs/2026-04-20-beads-comparison-design.md
@@ -1,0 +1,267 @@
+# Design: git-native-issue vs Beads Comparison Document
+
+**Date**: 2026-04-20
+**Status**: Draft
+**Author**: Emerson Soares
+
+## Purpose
+
+First entry in a comparison series (`docs/comparisons/<tool>.md`) analyzing
+competing distributed issue trackers against git-native-issue. Each document
+serves dual purpose:
+
+1. **Public positioning** — advocacy with honesty for potential adopters
+2. **Roadmap input** — identifies which competitor features are worth adding,
+   which are solvable with existing primitives, and which are architectural bloat
+
+Future entries: git-bug, Fossil, Bugs Everywhere, git-appraise, etc.
+A summary table in `docs/comparisons/README.md` will link all entries.
+
+## Target Audience
+
+Mixed technical level. Git-literate developers who understand commits, refs,
+and merge at a conceptual level. Layered depth: accessible arguments first
+(zero deps, portable), technical depth for those who want it (trailers,
+merge primitives, for-each-ref queries).
+
+## Tone
+
+Advocacy with honesty. Written from git-native-issue's perspective.
+Acknowledges competitor strengths, makes clear judgments about tradeoffs,
+never dismisses features without reasoning.
+
+## Output
+
+**File**: `docs/comparisons/beads.md`
+
+## Document Structure
+
+### 1. Header + At a Glance
+
+Quick-reference comparison table covering: storage, language, lines of code,
+dependencies, binary size, merge strategy, spec availability, license.
+
+One-paragraph verdict immediately below the table: git-native-issue treats
+Git as the database; Beads brings a separate database alongside Git. Both
+solve distributed issue tracking; git-native-issue does it with zero
+dependencies beyond Git.
+
+### 2. What They Have in Common
+
+Brief section (~150 words). Shared ground:
+
+- Both reject centralized trackers (GitHub Issues, Jira) as single points
+  of failure
+- Both use hash-based IDs for collision-free distributed work (UUID v4 vs
+  hash-derived bd-xxxx)
+- Both sync via push/pull rather than webhooks or polling
+- Both bridge to GitHub, GitLab, Gitea, Azure DevOps
+
+Purpose: establish that the divergence is architectural, not functional.
+
+### 3. The Fundamental Fork
+
+The philosophical centerpiece (~300 words).
+
+Two competing theses:
+
+- **Beads**: "Issues need a real database; Git is the wrong abstraction for
+  queries and graphs." Ships Dolt (version-controlled SQL) as storage engine.
+- **git-native-issue**: "Git already IS a distributed append-only
+  content-addressable database. Issues are commits, identity is refs,
+  metadata is trailers, merge is Git merge."
+
+Name the fork explicitly. Frame the rest of the document as evidence for the
+Git-native thesis.
+
+### 4. Storage: Commits + Refs + Trailers vs Dolt SQL
+
+Concrete comparison (~400 words).
+
+**git-native-issue model:**
+
+```
+refs/issues/<uuid> → commit chain (append-only)
+  ├── root commit: title (subject) + metadata (trailers)
+  ├── comment commits: body text
+  └── state-change commits: State: trailer
+  All point to empty tree (4b825dc...)
+```
+
+- Human-readable via `git log refs/issues/*`
+- Tamper-evident (SHA-based content addressing)
+- Zero bytes overhead beyond Git objects
+- Works in bare repos, no working tree needed
+
+**Beads model:**
+
+```
+.beads/embeddeddolt/ → Dolt database
+  ├── issues table (id, title, status, priority, type, ...)
+  ├── dependencies table (graph edges)
+  ├── comments, events, labels, wisps, ...
+  └── refs/dolt/data (Dolt's own ref namespace)
+```
+
+- Full SQL query power (indexes, joins, foreign keys)
+- Cell-level versioning
+- ~200MB binary + database files
+- Requires Dolt engine (embedded or server mode)
+
+Key argument: git-native-issue's storage IS Git. Beads' storage is a
+parallel system that happens to have Git-like properties.
+
+### 5. Merge: Git's Own Primitives vs an External Engine
+
+~300 words. Core argument: git-native-issue does not invent merge semantics.
+It composes Git's existing primitives:
+
+- **Comments**: Union of commit chains (how Git merge works by default)
+- **Labels**: Three-way set merge via `git merge-base` + `comm` + `sort`
+  (standard UNIX tools from the 1970s)
+- **Scalars**: Last-writer-wins via `%(authordate)` (Git's own timestamp)
+- **Merge commits**: `git commit-tree` with two parents (Git plumbing)
+
+The ISSUE-FORMAT.md spec contribution is policy decisions over these
+primitives (labels use set merge, additions beat removals, etc.), not new
+algorithms.
+
+Beads delegates merge to Dolt's cell-level engine — a separate system with
+its own semantics that users must trust as a black box.
+
+### 6. The Dependency Graph Question
+
+The key rebuttal section (~500 words). Beads' strongest selling point is
+its dependency graph (`dep add/remove/tree`, `bd ready`, cycle detection).
+
+Argument: this is a data modeling problem, not a storage engine problem.
+Git trailers model the same graph:
+
+```
+Blocks: a7f3b2c
+Blocked-By: c4e5f6d
+Parent: b8c9d0e
+Related: f1a2b3c
+```
+
+These are append-only, queryable via `git log --format='%(trailers:key=Blocks)'`,
+and merge-safe (union semantics).
+
+Show how GitHub Issues models epics, stories, tasks, and blockers with zero
+built-in hierarchy — using labels + cross-references. git-native-issue's
+trailers are MORE structured than GitHub's freeform markdown.
+
+A ready queue is: "open issues where no unresolved Blocked-By target exists."
+Computable with `git for-each-ref` + awk.
+
+Acknowledge: this is a feature gap today, not an architectural limitation.
+Closing it requires new trailers in the spec + ~3 new commands (~200 lines
+of shell), not a database migration.
+
+### 7. Agent Integration
+
+~250 words. Beads was designed agent-first: JSON output everywhere,
+atomic `--claim`, `bd ready`, built-in Anthropic SDK, MCP server.
+
+git-native-issue approaches this via plugins (claude-git-native-issue)
+rather than baking agent concerns into the core tool.
+
+Argument: keeping the core tool human-first is a feature, not a limitation.
+Trailers ARE structured data — agents consume them naturally. A `--json`
+output flag is a small addition. Agent orchestration (molecules, gates,
+formulas) belongs in orchestration tools, not issue trackers.
+
+### 8. What Beads Has That We Don't (And Whether It Matters)
+
+~400 words. Tiered honest assessment:
+
+**Tier 1 — Worth considering (small additions that close real gaps):**
+
+- `--json` output flag for machine consumption
+- Dependency trailers (`Blocks:`, `Blocked-By:`, `Parent:`)
+- `git issue ready` command (unblocked task query)
+- `git issue dep tree` command (dependency visualization)
+
+**Tier 2 — Interesting but out of scope:**
+
+- Molecules, formulas, gates — workflow orchestration primitives that belong
+  in a separate tool
+- Hierarchical IDs (`bd-a3f8.1.1`) — convenient but solvable with `Parent:`
+  trailers
+- Multi-repo federation — interesting for enterprise, premature for v1.x
+- Contributor/maintainer role detection — solves a Beads-specific problem
+  (keeping planning DBs out of PRs)
+
+**Tier 3 — Architectural bloat:**
+
+- Wisps (ephemeral TTL messages in an append-only tracker — contradicts the
+  model)
+- Compaction/memory decay (rewriting history contradicts content-addressable
+  design)
+- OpenTelemetry (observability for an issue tracker CLI tool?)
+- 212 Go module dependencies for a task that shell scripts handle
+
+### 9. Feature Matrix
+
+Comprehensive table. Every feature from both tools, side by side.
+
+Categories:
+
+- Core (create, list, show, edit, state, search, comment)
+- Dependencies & hierarchy
+- Collaboration (assign, claim, comment)
+- Sync & bridges (GitHub, GitLab, Gitea, Azure DevOps, Jira, Linear)
+- Agent support (JSON output, MCP, ready queue, claim)
+- Maintenance (fsck, compact, gc, doctor)
+- Data properties (tamper-evident, human-readable, spec-driven, bare repo)
+
+Values: checkmark, "planned", "N/A — by design" (for deliberate omissions).
+
+### 10. When to Use Which
+
+Closing section (~200 words). Clear guidance:
+
+**Use git-native-issue when:**
+
+- You already use Git and want zero new dependencies
+- Issues should travel with your code (clone includes issues)
+- You value a formal spec that other tools can implement
+- Human readability matters (`git log` shows your issues)
+- You work in environments where a 200MB binary is impractical
+
+**Consider Beads when:**
+
+- Your primary users are AI agents, not humans
+- You need complex SQL queries over issue data
+- Your team already uses Dolt
+- You need Jira/Linear sync specifically
+
+Honest, not dismissive.
+
+## Roadmap Implications
+
+Not included in the public document. Captured separately as issues in the
+git-native-issue tracker:
+
+1. Add `--json` output flag to `git issue ls` and `git issue show`
+2. Spec new trailers: `Blocks:`, `Blocked-By:`, `Parent:`, `Related:`
+3. Add `git issue dep add/remove/list/tree` commands
+4. Add `git issue ready` command
+5. Consider `--format json` as alternative to `--json` flag
+
+## Non-Goals
+
+- This document does NOT propose implementing beads' features in
+  git-native-issue
+- This document does NOT change ISSUE-FORMAT.md
+- This document does NOT cover other competitors (separate documents)
+- No code changes result from this spec — it is a documentation deliverable
+
+## Success Criteria
+
+- Reader who knows neither tool can understand the architectural difference
+  in under 2 minutes (At a Glance + Verdict)
+- Reader evaluating tools gets a comprehensive feature matrix to reference
+- The dependency graph argument is convincing: trailers + Git merge solve
+  the same problem without a database
+- Honest about gaps without being self-deprecating

--- a/docs/superpowers/specs/2026-04-20-beads-comparison-design.md
+++ b/docs/superpowers/specs/2026-04-20-beads-comparison-design.md
@@ -41,6 +41,9 @@ never dismisses features without reasoning.
 Quick-reference comparison table covering: storage, language, lines of code,
 dependencies, binary size, merge strategy, spec availability, license.
 
+Note: Beads is MIT-licensed. The license comparison is neutral — both are
+permissive/copyleft open source. Do not frame license as a differentiator.
+
 One-paragraph verdict immediately below the table: git-native-issue treats
 Git as the database; Beads brings a separate database alongside Git. Both
 solve distributed issue tracking; git-native-issue does it with zero
@@ -53,7 +56,7 @@ Brief section (~150 words). Shared ground:
 - Both reject centralized trackers (GitHub Issues, Jira) as single points
   of failure
 - Both use hash-based IDs for collision-free distributed work (UUID v4 vs
-  hash-derived bd-xxxx)
+  content-hash in base36, e.g. `bd-a3f8e9`)
 - Both sync via push/pull rather than webhooks or polling
 - Both bridge to GitHub, GitLab, Gitea, Azure DevOps
 
@@ -105,7 +108,8 @@ refs/issues/<uuid> → commit chain (append-only)
 
 - Full SQL query power (indexes, joins, foreign keys)
 - Cell-level versioning
-- ~200MB binary + database files
+- Large installed footprint (Go binary with embedded Dolt engine — verify
+  exact size from release artifacts before publishing)
 - Requires Dolt engine (embedded or server mode)
 
 Key argument: git-native-issue's storage IS Git. Beads' storage is a
@@ -131,7 +135,7 @@ its own semantics that users must trust as a black box.
 
 ### 6. The Dependency Graph Question
 
-The key rebuttal section (~500 words). Beads' strongest selling point is
+The key rebuttal section (~600 words). Beads' strongest selling point is
 its dependency graph (`dep add/remove/tree`, `bd ready`, cycle detection).
 
 Argument: this is a data modeling problem, not a storage engine problem.
@@ -144,19 +148,38 @@ Parent: b8c9d0e
 Related: f1a2b3c
 ```
 
-These are append-only, queryable via `git log --format='%(trailers:key=Blocks)'`,
-and merge-safe (union semantics).
+These are append-only and merge-safe (union semantics).
+
+**Querying**: Be honest about the cost. Querying trailers requires iterating
+issue refs — `git for-each-ref refs/issues/` to collect tips, then inspecting
+each tip commit's trailers. This is O(n) over all issues, not an indexed
+lookup like Dolt's SQL. For most repositories (hundreds of issues), this is
+fast. For thousands, it's slower than SQL but still tractable — the same
+pattern `git issue ls` already uses for filtering by label or priority.
+The tradeoff is: no new dependency for queries that are "fast enough" at
+realistic scale.
+
+**Cycle detection**: Don't hand-wave this. Detecting cycles in a
+trailer-based graph requires a full DFS traversal across all `Blocks:`/
+`Blocked-By:` relationships. This is non-trivial but well-understood — a
+standard graph DFS in awk or shell. Acknowledge the implementation cost
+honestly.
 
 Show how GitHub Issues models epics, stories, tasks, and blockers with zero
 built-in hierarchy — using labels + cross-references. git-native-issue's
 trailers are MORE structured than GitHub's freeform markdown.
 
 A ready queue is: "open issues where no unresolved Blocked-By target exists."
-Computable with `git for-each-ref` + awk.
+Requires collecting all open issues' Blocked-By trailers, checking which
+targets are still open, and filtering. Not a one-liner, but the same
+algorithmic complexity as any graph-based ready queue.
 
 Acknowledge: this is a feature gap today, not an architectural limitation.
-Closing it requires new trailers in the spec + ~3 new commands (~200 lines
-of shell), not a database migration.
+Closing it requires new trailers in the spec + ~5 new commands (dep add,
+dep remove, dep list, dep tree, ready) plus cycle detection and validation.
+Realistic estimate: 400-600 lines of shell, not a database migration. This
+is meaningful work but proportional — git-native-issue's existing commands
+average 100-150 lines each.
 
 ### 7. Agent Integration
 
@@ -166,10 +189,12 @@ atomic `--claim`, `bd ready`, built-in Anthropic SDK, MCP server.
 git-native-issue approaches this via plugins (claude-git-native-issue)
 rather than baking agent concerns into the core tool.
 
-Argument: keeping the core tool human-first is a feature, not a limitation.
-Trailers ARE structured data — agents consume them naturally. A `--json`
-output flag is a small addition. Agent orchestration (molecules, gates,
-formulas) belongs in orchestration tools, not issue trackers.
+Note: Beads IS human-usable — it has a full CLI and TUI. The argument is
+not that Beads sacrificed human usability, but that agent-specific concerns
+(molecules, gates, formulas, built-in LLM SDKs) don't need to live in the
+issue tracker's core. Trailers ARE structured data — agents consume them
+naturally. A `--json` output flag is a small addition. Agent orchestration
+belongs in orchestration tools, not issue trackers.
 
 ### 8. What Beads Has That We Don't (And Whether It Matters)
 
@@ -194,10 +219,11 @@ formulas) belongs in orchestration tools, not issue trackers.
 
 **Tier 3 — Architectural bloat:**
 
-- Wisps (ephemeral TTL messages in an append-only tracker — contradicts the
-  model)
+- Wisps (ephemeral TTL messages in an issue tracker — adds complexity with
+  unclear benefit; while append-only systems can support TTL (e.g. Kafka),
+  it's unclear this belongs in issue tracking)
 - Compaction/memory decay (rewriting history contradicts content-addressable
-  design)
+  design; optimizes for AI context windows at the cost of auditability)
 - OpenTelemetry (observability for an issue tracker CLI tool?)
 - 212 Go module dependencies for a task that shell scripts handle
 
@@ -216,6 +242,10 @@ Categories:
 - Data properties (tamper-evident, human-readable, spec-driven, bare repo)
 
 Values: checkmark, "planned", "N/A — by design" (for deliberate omissions).
+
+Pin the comparison to a specific Beads release (v1.0.2 as of 2026-04-20)
+and include a "last verified" date at the top. This prevents staleness
+without creating ongoing maintenance burden.
 
 ### 10. When to Use Which
 


### PR DESCRIPTION
## Summary

- First entry in a `docs/comparisons/` series analyzing competing distributed issue trackers
- Covers architecture, storage, merge, dependency graphs, agent integration, and comprehensive feature matrix
- Advocacy with honesty: acknowledges Beads' strengths (dependency graph, SQL queries, agent-first design) while making the case for Git-native primitives
- Includes design spec and implementation plan in `docs/superpowers/`

## Key arguments

- **Storage**: Git commits + refs + trailers vs Dolt SQL — zero dependencies vs 212 Go modules
- **Merge**: Git's own merge primitives vs Dolt's cell-level engine
- **Dependencies**: Feature gap, not architectural limitation — trailers model the same graph
- **Agents**: Plugin approach vs baking agent concerns into the core

## Test plan

- [ ] Verify all links in `beads.md` resolve correctly
- [ ] Verify `docs/comparisons/README.md` links to `beads.md`
- [ ] Read through for tone: advocacy with honesty, not dismissive
- [ ] Cross-check feature matrix against both projects' current READMEs