### PR TITLE
spec: add RECOMMENDED label normalization

### DIFF
--- a/ISSUE-FORMAT.md
+++ b/ISSUE-FORMAT.md
@@ -327,7 +327,10 @@ Labels: label1, label2, label3
 
 When comparing labels for merge operations (Section 6.3), implementations
 MUST trim whitespace and compare the resulting strings exactly
-(case-sensitive).
+(case-sensitive). Implementations SHOULD normalize labels to lowercase
+before comparison to avoid case-variant duplicates (e.g., `bug` and `Bug`
+being treated as distinct labels). This normalization is RECOMMENDED but
+not REQUIRED, to preserve intentional casing (e.g., `iOS`, `API`, `UI`).
 
 ### 4.8 Formal Grammar (ABNF)
 
@@ -549,7 +552,8 @@ known limitations:
 **1. Case Variants**:
 - `bug` and `Bug` are distinct labels
 - Concurrent addition of both creates duplicates: `bug, Bug`
-- Resolution: Manual cleanup or project conventions
+- Resolution: Implementations SHOULD apply lowercase normalization per
+  Section 4.7. Projects SHOULD establish consistent casing conventions.
 
 **2. Semantic Duplicates**:
 - `enhancement` and `feature` are distinct labels


### PR DESCRIPTION
## Summary
Add RECOMMENDED label normalization (closes #133)

Added a SHOULD statement to Section 4.7 that implementations normalize labels to lowercase before comparison, to avoid case-variant duplicates like `bug` vs `Bug`. Marked as RECOMMENDED not REQUIRED to preserve intentional casing (e.g., iOS, API, UI). Referenced from Section 6.3.1 where the case-variant limitation is documented.

Split from #148 — needs the normative conflict resolved (tension with existing case-sensitive MUST) before merging. See review discussion on #148 for context.

## Test plan
- Spec-only change — no code modified
- `make test`: all tests pass unchanged